### PR TITLE
chore: Publish package on npm on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+            node-version-file: '.nvmrc'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-            node-version-file: '.nvmrc'
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - run: 📦 npm publish --provenance --access public
+      - name: 📦 Publish to NPM
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,32 @@
+
+name: Publish NPM Package
+
+on:
+  push:
+    tags:
+      -  v*
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: write # required to get token for "npm provenance" and to dispatch event
+    steps:
+      - name: Set VERSION
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v*}" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - run: 📦 npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        description: 'New version type [new-version | major | minor | patch]'
+        required: true
+        default: 'patch'
+jobs:
+  bumpVersion:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - run: |
+          echo "New version type: ${{ inputs.type }}"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+      - name: Config git
+        run: |
+          git config --local user.email "${{ github.actor }}@users.noreply.github.com"
+          git config --local user.name "${{ github.actor }}"
+          git config pull.rebase true
+      - name: Checkout main
+        run: git checkout main && git pull --tags
+      - name: Bump Version
+        run: |
+          npm version ${{ inputs.type }} --no-commit-hooks --message "chore(release): %s"
+      - name: Push Version
+        run: git push && git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
       contents: write
 
     steps:
+      - name: 🔧 Git Setup
+        uses: bonitasoft/git-setup-action@v1
+        with:
+          keeper-secret-config: ${{ secrets.KSM_CONFIG }}
       - run: |
           echo "New version type: ${{ inputs.type }}"
       - uses: actions/checkout@v4
@@ -27,11 +31,7 @@ jobs:
 
       - name: Build
         run: npm run build
-      - name: Config git
-        run: |
-          git config --local user.email "${{ github.actor }}@users.noreply.github.com"
-          git config --local user.name "${{ github.actor }}"
-          git config pull.rebase true
+
       - name: Checkout main
         run: git checkout main && git pull --tags
       - name: Bump Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         run: npm ci

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-test/
-*.test.js
-

--- a/fixup.sh
+++ b/fixup.sh
@@ -1,10 +1,10 @@
-cat >dist/cjs/package.json <<!EOF
+cat >lib/cjs/package.json <<!EOF
 {
     "type": "commonjs"
 }
 !EOF
 
-cat >dist/mjs/package.json <<!EOF
+cat >lib/mjs/package.json <<!EOF
 {
     "type": "module"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonitasoft/antora-detect-unused-media-extension",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonitasoft/antora-detect-unused-media-extension",
-      "version": "1.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@antora/content-classifier": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "Antora extension to detect unused media files in a Antora project.",
   "scripts": {
-    "build:js": "rm -fr dist/* && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && ./fixup.sh",
+    "build:js": "rm -fr lib/* && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && ./fixup.sh",
     "build": "npm run lint && npm run test && npm run build:js",
     "lint": "eslint src tests",
     "lint:fix": "eslint --fix src tests",
@@ -13,14 +13,15 @@
     "test:cov": "node --test --experimental-test-coverage",
     "prepack": "npm run build"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/mjs/index.js",
+  "main": "lib/cjs/index.js",
+  "module": "lib/mjs/index.js",
   "exports": {
     ".": {
-      "import": "./dist/mjs/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": "./lib/mjs/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
+  "files": ["lib/*", "README.adoc"],
   "keywords": [
     "antora",
     "extension",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonitasoft/antora-detect-unused-media-extension",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "type": "module",
   "description": "Antora extension to detect unused media files in a Antora project.",
   "scripts": {
@@ -21,7 +21,10 @@
       "require": "./lib/cjs/index.js"
     }
   },
-  "files": ["lib/*", "README.adoc"],
+  "files": [
+    "lib/*",
+    "README.adoc"
+  ],
   "keywords": [
     "antora",
     "extension",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "node --test --test-reporter spec --test-reporter-destination stdout --test-reporter node-test-github-reporter --test-reporter-destination stdout",
     "test:watch": "node --test --watch",
     "test:cov": "node --test --experimental-test-coverage",
-    "prepack": "npm run build"
+    "prepack": "npm run build:js"
   },
   "main": "lib/cjs/index.js",
   "module": "lib/mjs/index.js",

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -20,6 +20,6 @@
     "types": ["node"]
   },
   "compileOnSave": false,
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "lib"],
   "include": ["src"]
 }

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist/cjs",
+    "outDir": "lib/cjs",
     "target": "es2015"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "esnext",
-    "outDir": "dist/mjs",
+    "outDir": "lib/mjs",
     "target": "esnext"
   }
 }


### PR DESCRIPTION
Adding workflow to release a new version of `bonitasoft/antora-detect-unused-media-extension` .

When a tag is pushed, the publish-npm.yml workflow is called and the new version of package is published.

* Move the dist files into a lib folder
* Create two worflows, publish-npm and release

## Note
The version of package is set to 0.0.1 to allow us to make test.
