### PR TITLE
feat: Detect media in partial

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,9 +32,9 @@ export function register({ config }) {
       Array.from(extensionToIgnore),
     );
 
-    const imageReferences = extractImageReferences(contentCatalog, logger);
+    const imageReferences = extractMediaReferences(contentCatalog, logger);
 
-    const unusedImages = findUnusedImages(
+    const unusedImages = findUnusedmedia(
       contentCatalog,
       imageReferences,
       extensionToIgnore,
@@ -43,26 +43,27 @@ export function register({ config }) {
 
     if (unusedImages.size > 0) {
       logger.warn(
-        "Some images are unused, check previous logs and delete unused images.",
+        "Some media are unused, check previous logs and delete unused media.",
       );
     }
   });
 }
 
-export function extractImageReferences(contentCatalog, logger) {
-  const imageReferences = new Set();
+export function extractMediaReferences(contentCatalog, logger) {
+  const mediaReferences = new Set();
+  const families = ["page", "partial"];
 
   contentCatalog
     .getFiles()
-    .filter((file) => file.src.family === "page")
+    .filter((file) => families.includes(file.src.family))
     .forEach((file) => {
       try {
         if (file.contents) {
-          const imageMatches =
+          const mediaMatches =
             file.contents.toString().match(/(image|video)::?([^[]+)/g) || [];
-          imageMatches.forEach((match) => {
+          mediaMatches.forEach((match) => {
             const imagePath = match.replace(/(image|video)::?/g, "").trim();
-            imageReferences.add(imagePath);
+            mediaReferences.add(imagePath);
           });
         }
       } catch (error) {
@@ -76,17 +77,17 @@ export function extractImageReferences(contentCatalog, logger) {
       }
     });
 
-  logger.info("Found %s images references", imageReferences.size);
-  return imageReferences;
+  logger.info("Found %s media references", mediaReferences.size);
+  return mediaReferences;
 }
 
-export function findUnusedImages(
+export function findUnusedmedia(
   contentCatalog,
-  imageReferences,
+  mediaReferences,
   extensionToIgnore,
   logger,
 ) {
-  const unusedImages = new Set();
+  const unusedmedia = new Set();
   contentCatalog
     .getFiles()
     .filter(
@@ -98,13 +99,13 @@ export function findUnusedImages(
       // ex: ROOT:images/myImage.png or images:myImages.png
       if (
         !(
-          imageReferences.has(img.src.relative.toString()) ||
-          imageReferences.has(
+          mediaReferences.has(img.src.relative.toString()) ||
+          mediaReferences.has(
             img.src.module + ":" + img.src.relative.toString(),
           )
         )
       ) {
-        unusedImages.add(img);
+        unusedmedia.add(img);
         logger.warn(
           "[%s] [%s] %s",
           img.src.component,
@@ -113,6 +114,6 @@ export function findUnusedImages(
         );
       }
     });
-  logger.info("Finish and detecting %s unused images", unusedImages.size);
-  return unusedImages;
+  logger.info("Finish and detecting %s unused media", unusedmedia.size);
+  return unusedmedia;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -34,14 +34,14 @@ export function register({ config }) {
 
     const imageReferences = extractMediaReferences(contentCatalog, logger);
 
-    const unusedImages = findUnusedmedia(
+    const unusedMedia = findUnusedMedia(
       contentCatalog,
       imageReferences,
       extensionToIgnore,
       logger,
     );
 
-    if (unusedImages.size > 0) {
+    if (unusedMedia.size > 0) {
       logger.warn(
         "Some media are unused, check previous logs and delete unused media.",
       );
@@ -81,13 +81,13 @@ export function extractMediaReferences(contentCatalog, logger) {
   return mediaReferences;
 }
 
-export function findUnusedmedia(
+export function findUnusedMedia(
   contentCatalog,
   mediaReferences,
   extensionToIgnore,
   logger,
 ) {
-  const unusedmedia = new Set();
+  const unusedMedia = new Set();
   contentCatalog
     .getFiles()
     .filter(
@@ -105,7 +105,7 @@ export function findUnusedmedia(
           )
         )
       ) {
-        unusedmedia.add(img);
+        unusedMedia.add(img);
         logger.warn(
           "[%s] [%s] %s",
           img.src.component,
@@ -114,6 +114,6 @@ export function findUnusedmedia(
         );
       }
     });
-  logger.info("Finish and detecting %s unused media", unusedmedia.size);
-  return unusedmedia;
+  logger.info("Finish and detecting %s unused media", unusedMedia.size);
+  return unusedMedia;
 }

--- a/tests/detect-unused-media.test.js
+++ b/tests/detect-unused-media.test.js
@@ -2,7 +2,7 @@ import { strict as assert } from "node:assert"; // Importing assert
 import { beforeEach, describe, it } from "node:test";
 import {
   extractMediaReferences,
-  findUnusedmedia,
+  findUnusedMedia,
   register,
 } from "../src/index.js";
 import { createLogger } from "./lib.js";
@@ -112,7 +112,7 @@ describe("findUnusedImages", () => {
     const mediaReferences = new Set(["images/img1.png"]);
     const extensionToIgnore = new Set([".cast"]);
 
-    const result = findUnusedmedia(
+    const result = findUnusedMedia(
       contentCatalog,
       mediaReferences,
       extensionToIgnore,

--- a/tests/detect-unused-media.test.js
+++ b/tests/detect-unused-media.test.js
@@ -1,14 +1,14 @@
 import { strict as assert } from "node:assert"; // Importing assert
 import { beforeEach, describe, it } from "node:test";
 import {
-  extractImageReferences,
-  findUnusedImages,
+  extractMediaReferences,
+  findUnusedmedia,
   register,
 } from "../src/index.js";
 import { createLogger } from "./lib.js";
 
-describe("extractImageReferences", async () => {
-  it("should extract image references from one file", () => {
+describe("extractMediaReferences", async () => {
+  it("should extract media references from one file", () => {
     const logger = createLogger();
     const contentCatalog = {
       getFiles: () => [
@@ -20,7 +20,7 @@ describe("extractImageReferences", async () => {
       ],
     };
 
-    const imageReferences = extractImageReferences(contentCatalog, logger);
+    const imageReferences = extractMediaReferences(contentCatalog, logger);
 
     assert.strictEqual(imageReferences.size, 3);
     assert.strictEqual(imageReferences.has("path/to/image1.png"), true);
@@ -28,7 +28,7 @@ describe("extractImageReferences", async () => {
     assert.strictEqual(imageReferences.has("component:modules/cat.gif"), true);
   });
 
-  it("should extract image references from multiple files", () => {
+  it("should extract media references from multiple files", () => {
     const logger = createLogger();
     const contentCatalog = {
       getFiles: () => [
@@ -41,12 +41,36 @@ describe("extractImageReferences", async () => {
       ],
     };
 
-    const imageReferences = extractImageReferences(contentCatalog, logger);
+    const imageReferences = extractMediaReferences(contentCatalog, logger);
 
     assert.strictEqual(imageReferences.size, 3);
     assert.strictEqual(imageReferences.has("path/to/image1.png"), true);
     assert.strictEqual(imageReferences.has("path/to/image2.cast"), true);
     assert.strictEqual(imageReferences.has("component:modules/cat.gif"), true);
+  });
+
+  it("should extract media references from file and partial", () => {
+    const logger = createLogger();
+    const contentCatalog = {
+      getFiles: () => [
+        {
+          src: { family: "page" },
+          contents:
+            "image::path/to/image1.png[] \n \n image:component:modules/cat.gif[]",
+        },
+        {
+          src: { family: "partial" },
+          contents: "Load a .cast in the partial image::path/to/image2.cast[]",
+        },
+      ],
+    };
+
+    const mediaReferences = extractMediaReferences(contentCatalog, logger);
+
+    assert.strictEqual(mediaReferences.size, 3);
+    assert.strictEqual(mediaReferences.has("path/to/image1.png"), true);
+    assert.strictEqual(mediaReferences.has("path/to/image2.cast"), true);
+    assert.strictEqual(mediaReferences.has("component:modules/cat.gif"), true);
   });
 });
 
@@ -61,7 +85,7 @@ describe("findUnusedImages", () => {
     logger = createLogger();
   });
 
-  it("returns unused images when there are images not referenced", () => {
+  it("returns unused media when there are media not referenced", () => {
     contentCatalog.getFiles = () => [
       {
         src: {
@@ -85,12 +109,12 @@ describe("findUnusedImages", () => {
       },
     ];
 
-    const imageReferences = new Set(["images/img1.png"]);
+    const mediaReferences = new Set(["images/img1.png"]);
     const extensionToIgnore = new Set([".cast"]);
 
-    const result = findUnusedImages(
+    const result = findUnusedmedia(
       contentCatalog,
-      imageReferences,
+      mediaReferences,
       extensionToIgnore,
       logger,
     );
@@ -112,7 +136,7 @@ describe("findUnusedImages", () => {
 });
 
 describe("Extension should", () => {
-  it("register function should log unused images", () => {
+  it("register function should log unused media", () => {
     const logger = createLogger();
 
     const context = {
@@ -143,10 +167,10 @@ describe("Extension should", () => {
     // Add assertion
     assert.strictEqual(
       logger.messages.warn.includes(
-        "Some images are unused, check previous logs and delete unused images.",
+        "Some media are unused, check previous logs and delete unused media.",
       ),
       true,
-      "Logger should warn about unused images",
+      "Logger should warn about unused media",
     );
   });
 });


### PR DESCRIPTION
Media can be searched in page or partial content. 

It's to avoid getting media flagged as unused even if partial content includes it.

Closes: #5